### PR TITLE
Update minecraft_proxy.py

### DIFF
--- a/minecraft_proxy.py
+++ b/minecraft_proxy.py
@@ -5,13 +5,16 @@ from twisted.internet import reactor
 class PacketBridge(Bridge):
     verbose = False
 
-    def packet_upstream_chat_message(self, buff):
+    def packet_upstream_chat_command(self, buff):
+        buff.save()
         message = buff.unpack_string()
 
-        if message.startswith("/verbose"):
+        if message == "verbose":
             self.verbose = not self.verbose
+            buff.discard()
         else:
-            self.upstream.send_packet("chat_message", buff.read())
+            buff.restore
+            self.upstream.send_packet("chat_command", buff.read())
 
     def packet_unhandled(self, buff, direction, name):
         if self.verbose:
@@ -42,7 +45,7 @@ def main(argv):
 
     factory = QuietDownStreamFactory()
     factory.connect_host = args.connect_host
-    factory.connect_porty = args.connect_port
+    factory.connect_port = args.connect_port
 
     factory.listen(args.listen_host, args.listen_port)
     reactor.run()

--- a/minecraft_proxy.py
+++ b/minecraft_proxy.py
@@ -13,7 +13,7 @@ class PacketBridge(Bridge):
             self.verbose = not self.verbose
             buff.discard()
         else:
-            buff.restore
+            buff.restore()
             self.upstream.send_packet("chat_command", buff.read())
 
     def packet_unhandled(self, buff, direction, name):


### PR DESCRIPTION
you can now send chat messages and commands without crashing and i fixed a typo. also /verbose works with this. should note i play on 1.19.2 so if it worked in older versions then these changes might break it. maybe add a check of some kind that changes how it works depending on the version like in quarrys example hide chat proxy script if you care?